### PR TITLE
LSHアルゴリズムの実装と行列をハッシュ値からソートするように変更

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -4,7 +4,7 @@ FROM python:3.8-slim
 # 必要なパッケージのインストール
 RUN apt-get update && apt-get install -y gcc python3-dev
 RUN pip install jupyterlab
-
+RUN pip install scikit-learn
 RUN pip install torch 
 RUN pip install numpy
 RUN pip install importnb

--- a/work/scripts/algorithm.py
+++ b/work/scripts/algorithm.py
@@ -1,0 +1,37 @@
+## 変更できる場所としてはnum_lengthをコンストラクタで定義するかどうか
+## 定義しておけば変換が可逆になる(元の行列に戻したい時にできるようになる)
+## 定義しなければ引数で与えるものが少なくなるので呼び出しが楽になる
+import torch
+import numpy as np
+class Calculate_LSH:
+    def __init__(
+        self,
+        d_model:int,
+        num_length:int,
+        num_buckets:int,
+    )->None:
+        ## define random matrix for rotation
+        self.R = np.random.randn(d_model,int(num_buckets/2))
+        ## define vectors to store labels
+        ## ここは別にハッシュ計算部分で個別に定義してもいいけど変換を可逆にしたい時に便利かなって思ったのでこうしてます
+        self.labels = torch.randint(high=num_buckets,size=(num_length,))
+    def raw_to_sorted_data(
+        self,
+        input:torch.tensor,
+    )-> torch.tensor:
+        ##requires->行列
+        ##effects->ハッシュを元に各ベクトルのラベルを求め、ラベルごとに行列をソート
+        self.labels = self.__cal_hash(input)
+        sorted_indices = self.labels.argsort()
+        return input[sorted_indices]
+    def __cal_hash(
+        self,
+        input:torch.tensor,
+    ):
+        ## requires->行列
+        ## effects->ハッシュを計算、単語ごとにハッシュを割り当ててラベルベクトルとして返す。
+        x_R = input@self.R
+        x_R = torch.cat([x_R, -x_R], dim=1)
+        ## argmaxに書き換えてもいいけどmax使った方がhashの値まで見えていいかなと思ってこっちにしてる
+        hash = torch.max(x_R,dim=1).indices
+        return hash

--- a/work/scripts/algorithm.py
+++ b/work/scripts/algorithm.py
@@ -27,7 +27,7 @@ class Calculate_LSH:
     def __cal_hash(
         self,
         input:torch.tensor,
-    ):
+    )-> torch.tensor:
         ## requires->行列
         ## effects->ハッシュを計算、単語ごとにハッシュを割り当ててラベルベクトルとして返す。
         x_R = input@self.R

--- a/work/scripts/algorithm.py
+++ b/work/scripts/algorithm.py
@@ -3,19 +3,21 @@
 ## 定義しなければ引数で与えるものが少なくなるので呼び出しが楽になる
 import torch
 import numpy as np
-class Calculate_LSH:
+from torch import nn
+class Calculate_LSH(nn.Module):
     def __init__(
         self,
         d_model:int,
         num_length:int,
         num_buckets:int,
     )->None:
+        super().__init__()
         ## define random matrix for rotation
-        self.R = np.random.randn(d_model,int(num_buckets/2))
+        self.R = torch.randn(size = (d_model,int(num_buckets/2)))
         ## define vectors to store labels
         ## ここは別にハッシュ計算部分で個別に定義してもいいけど変換を可逆にしたい時に便利かなって思ったのでこうしてます
         self.labels = torch.randint(high=num_buckets,size=(num_length,))
-    def raw_to_sorted_data(
+    def forward(
         self,
         input:torch.tensor,
     )-> torch.tensor:
@@ -23,11 +25,12 @@ class Calculate_LSH:
         ##effects->ハッシュを元に各ベクトルのラベルを求め、ラベルごとに行列をソート
         self.labels = self.__cal_hash(input)
         sorted_indices = self.labels.argsort()
-        return input[sorted_indices]
+        input = torch.index_select(input, 0 , sorted_indices)
+        return input
     def __cal_hash(
         self,
         input:torch.tensor,
-    )-> torch.tensor:
+    ):
         ## requires->行列
         ## effects->ハッシュを計算、単語ごとにハッシュを割り当ててラベルベクトルとして返す。
         x_R = input@self.R

--- a/work/utils/test_code.ipynb
+++ b/work/utils/test_code.ipynb
@@ -260,8 +260,309 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 16,
    "id": "3fc4abcb-b48e-465b-ab3c-d28a95b8c3c0",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "num_of_hash = 4\n",
+    "d_model = 3"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3650c699-e1d3-4aff-b97b-f5d236375bdb",
+   "metadata": {},
+   "source": [
+    "### あらかじめx_1,2,3の類似度をそれぞれ測っておく"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 78,
+   "id": "7a186856-981d-4ab5-8c43-06712fd71b1b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from sklearn.metrics.pairwise import cosine_similarity as similarity\n",
+    "def generate_sample_data(d_model,num_of_hashes):\n",
+    "    ### 適当なベクトルを三つ生成\n",
+    "    x_1 = torch.randn(d_model)\n",
+    "    x_2 = torch.randn(d_model)\n",
+    "    x_3 = torch.randn(d_model)\n",
+    "    pairs = [(x_1,x_2,\"1-2\"),(x_1,x_3,\"1-3\"),(x_2,x_3,\"2-3\")]\n",
+    "    similarities = similarities = [(pair[2], similarity(pair[0].reshape(1,-1), pair[1].reshape(1,-1))) for pair in pairs]\n",
+    "    similarities = sorted(similarities, key=lambda x: x[1], reverse=True)\n",
+    "    print(similarities)\n",
+    "    ### 標準正規分布に従う行列を作成\n",
+    "    R = np.random.randn(d_model,int(num_of_hash/2))\n",
+    "    return ((x_1,x_2,x_3),R)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 116,
+   "id": "8a45fcbb-beb3-4315-8321-41b138ceaaea",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[('1-2', array([[-0.2635013]], dtype=float32)), ('1-3', array([[-0.41672304]], dtype=float32)), ('2-3', array([[-0.7318527]], dtype=float32))]\n"
+     ]
+    }
+   ],
+   "source": [
+    "vectors,R = generate_sample_data(d_model,num_of_hash)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 117,
+   "id": "9719aad0-a3b4-46f3-9256-4ee4c674f5ec",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def sample_lsh(input,R):\n",
+    "    x_R = input@R\n",
+    "    x_R = torch.cat([x_R, -x_R], dim=1)\n",
+    "    ## argmaxに書き換えてもいいけどmax使った方がhashの値まで見えていいかなと思ってこっちにしてる\n",
+    "    hash = torch.max(x_R,dim=1).indices\n",
+    "    return hash"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 118,
+   "id": "651eeeb1-070a-40e0-85e9-6f83004fc405",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "a = torch.vstack(\n",
+    "    [\n",
+    "        vectors[0],\n",
+    "        vectors[1],\n",
+    "        vectors[2]\n",
+    "    ]\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 119,
+   "id": "f2c65228-157e-4d32-ac98-deb6b409b93f",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "tensor([[ 2.3341, -1.9627,  0.5752],\n",
+       "        [ 0.3347,  0.6775, -1.7282],\n",
+       "        [-0.8408,  0.4555,  1.3133]])"
+      ]
+     },
+     "execution_count": 119,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "a"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 120,
+   "id": "fe683124-29a0-48b8-b0c3-68da440ab245",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "labels = sample_lsh(a,R)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 121,
+   "id": "4d0efb6e-80ea-47f6-81ec-46e40140d7ac",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "tensor([2, 1, 0])"
+      ]
+     },
+     "execution_count": 121,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "labels"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 122,
+   "id": "fd866257-ef82-4e63-adee-830b58d0345c",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "tensor([[ 2.3341, -1.9627,  0.5752],\n",
+       "        [ 0.3347,  0.6775, -1.7282],\n",
+       "        [-0.8408,  0.4555,  1.3133]])"
+      ]
+     },
+     "execution_count": 122,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "a"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 123,
+   "id": "a748ad2b-8437-4a2e-a5b0-c3eba72a28d8",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "sorted_indices = labels.argsort()\n",
+    "sorted_data = a[sorted_indices]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 124,
+   "id": "54c3ae82-62e9-4bb1-8447-0e5e43df414c",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "tensor([[-0.8408,  0.4555,  1.3133],\n",
+       "        [ 0.3347,  0.6775, -1.7282],\n",
+       "        [ 2.3341, -1.9627,  0.5752]])"
+      ]
+     },
+     "execution_count": 124,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "sorted_data"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 137,
+   "id": "8805f5a2-3e3e-4293-b0df-2306430a109d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "class Calculate_LSH:\n",
+    "    def __init__(\n",
+    "        self,\n",
+    "        d_model:int,\n",
+    "        num_length:int,\n",
+    "        num_buckets:int,\n",
+    "    )->None:\n",
+    "        ## define random matrix for rotation\n",
+    "        self.R = np.random.randn(d_model,int(num_buckets/2))\n",
+    "        ## define vectors to store labels\n",
+    "        ## ここは別にハッシュ計算部分で個別に定義してもいいけど変換を可逆にしたい時に便利かなって思ったのでこうしてます\n",
+    "        self.labels = torch.randint(high=num_buckets,size=(num_length,))\n",
+    "    def raw_to_sorted_data(\n",
+    "        self,\n",
+    "        input:torch.tensor,\n",
+    "    )-> torch.tensor:\n",
+    "        ##requires->行列\n",
+    "        ##effects->ハッシュを元に各ベクトルのラベルを求め、ラベルごとに行列をソート\n",
+    "        self.labels = self.__cal_hash(input)\n",
+    "        sorted_indices = self.labels.argsort()\n",
+    "        return input[sorted_indices]\n",
+    "    def __cal_hash(\n",
+    "        self,\n",
+    "        input:torch.tensor,\n",
+    "    ):\n",
+    "        ## requires->行列\n",
+    "        ## effects->ハッシュを計算、単語ごとにハッシュを割り当ててラベルベクトルとして返す。\n",
+    "        x_R = input@self.R\n",
+    "        x_R = torch.cat([x_R, -x_R], dim=1)\n",
+    "        ## argmaxに書き換えてもいいけどmax使った方がhashの値まで見えていいかなと思ってこっちにしてる\n",
+    "        hash = torch.max(x_R,dim=1).indices\n",
+    "        print(hash)\n",
+    "        return hash"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 141,
+   "id": "d0362771-a7f9-4baf-9a72-9d8c6c17dd04",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "model = Calculate_LSH(\n",
+    "    d_model = 3,\n",
+    "    num_length = 3,\n",
+    "    num_buckets = 4,\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 143,
+   "id": "ce2ddac6-6f8c-4737-8995-e954ee78e57f",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "tensor([3, 1, 3])\n",
+      "tensor([[ 0.3347,  0.6775, -1.7282],\n",
+      "        [ 2.3341, -1.9627,  0.5752],\n",
+      "        [-0.8408,  0.4555,  1.3133]])\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(model.raw_to_sorted_data(\n",
+    "    a\n",
+    "))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 144,
+   "id": "fdd8a120-797d-463e-8a0c-8a8e2a2270fd",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "tensor([3, 1, 3])"
+      ]
+     },
+     "execution_count": 144,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "model.labels"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "78806920-c70a-42a8-a3d0-9f25a3aec0a1",
    "metadata": {},
    "outputs": [],
    "source": []

--- a/work/utils/test_code.ipynb
+++ b/work/utils/test_code.ipynb
@@ -334,18 +334,29 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 118,
+   "execution_count": 176,
    "id": "651eeeb1-070a-40e0-85e9-6f83004fc405",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "ename": "TypeError",
+     "evalue": "vstack() got an unexpected keyword argument 'requires_grad'",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
+      "\u001b[0;31mTypeError\u001b[0m                                 Traceback (most recent call last)",
+      "Cell \u001b[0;32mIn[176], line 1\u001b[0m\n\u001b[0;32m----> 1\u001b[0m a \u001b[38;5;241m=\u001b[39m \u001b[43mtorch\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mvstack\u001b[49m\u001b[43m(\u001b[49m\n\u001b[1;32m      2\u001b[0m \u001b[43m    \u001b[49m\u001b[43m[\u001b[49m\n\u001b[1;32m      3\u001b[0m \u001b[43m        \u001b[49m\u001b[43mvectors\u001b[49m\u001b[43m[\u001b[49m\u001b[38;5;241;43m0\u001b[39;49m\u001b[43m]\u001b[49m\u001b[43m,\u001b[49m\n\u001b[1;32m      4\u001b[0m \u001b[43m        \u001b[49m\u001b[43mvectors\u001b[49m\u001b[43m[\u001b[49m\u001b[38;5;241;43m1\u001b[39;49m\u001b[43m]\u001b[49m\u001b[43m,\u001b[49m\n\u001b[1;32m      5\u001b[0m \u001b[43m        \u001b[49m\u001b[43mvectors\u001b[49m\u001b[43m[\u001b[49m\u001b[38;5;241;43m2\u001b[39;49m\u001b[43m]\u001b[49m\n\u001b[1;32m      6\u001b[0m \u001b[43m    \u001b[49m\u001b[43m]\u001b[49m\n\u001b[1;32m      7\u001b[0m \u001b[43m,\u001b[49m\u001b[43mrequires_grad\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[38;5;28;43;01mTrue\u001b[39;49;00m\u001b[43m)\u001b[49m\n",
+      "\u001b[0;31mTypeError\u001b[0m: vstack() got an unexpected keyword argument 'requires_grad'"
+     ]
+    }
+   ],
    "source": [
     "a = torch.vstack(\n",
     "    [\n",
     "        vectors[0],\n",
     "        vectors[1],\n",
     "        vectors[2]\n",
-    "    ]\n",
-    ")"
+    "    ])"
    ]
   },
   {
@@ -461,24 +472,26 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 137,
+   "execution_count": 165,
    "id": "8805f5a2-3e3e-4293-b0df-2306430a109d",
    "metadata": {},
    "outputs": [],
    "source": [
-    "class Calculate_LSH:\n",
+    "from torch import nn\n",
+    "class Calculate_LSH(nn.Module):\n",
     "    def __init__(\n",
     "        self,\n",
     "        d_model:int,\n",
     "        num_length:int,\n",
     "        num_buckets:int,\n",
     "    )->None:\n",
+    "        super().__init__()\n",
     "        ## define random matrix for rotation\n",
-    "        self.R = np.random.randn(d_model,int(num_buckets/2))\n",
+    "        self.R = torch.randn(size = (d_model,int(num_buckets/2)))\n",
     "        ## define vectors to store labels\n",
     "        ## ここは別にハッシュ計算部分で個別に定義してもいいけど変換を可逆にしたい時に便利かなって思ったのでこうしてます\n",
     "        self.labels = torch.randint(high=num_buckets,size=(num_length,))\n",
-    "    def raw_to_sorted_data(\n",
+    "    def forward(\n",
     "        self,\n",
     "        input:torch.tensor,\n",
     "    )-> torch.tensor:\n",
@@ -486,7 +499,8 @@
     "        ##effects->ハッシュを元に各ベクトルのラベルを求め、ラベルごとに行列をソート\n",
     "        self.labels = self.__cal_hash(input)\n",
     "        sorted_indices = self.labels.argsort()\n",
-    "        return input[sorted_indices]\n",
+    "        input = torch.index_select(input, 0 , sorted_indices)\n",
+    "        return input\n",
     "    def __cal_hash(\n",
     "        self,\n",
     "        input:torch.tensor,\n",
@@ -497,13 +511,12 @@
     "        x_R = torch.cat([x_R, -x_R], dim=1)\n",
     "        ## argmaxに書き換えてもいいけどmax使った方がhashの値まで見えていいかなと思ってこっちにしてる\n",
     "        hash = torch.max(x_R,dim=1).indices\n",
-    "        print(hash)\n",
     "        return hash"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 141,
+   "execution_count": 166,
    "id": "d0362771-a7f9-4baf-9a72-9d8c6c17dd04",
    "metadata": {},
    "outputs": [],
@@ -517,7 +530,40 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 143,
+   "execution_count": 183,
+   "id": "f6356111-4446-4606-bbeb-4c51d74055c9",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "a = torch.rand(size=(3,3),dtype=torch.float32,requires_grad=True)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 184,
+   "id": "924d73fa-5245-4e8f-9e59-e2a0bc6390a1",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "tensor([[0.4981, 0.3462, 0.0865],\n",
+       "        [0.9151, 0.9980, 0.9033],\n",
+       "        [0.3711, 0.4656, 0.9315]], requires_grad=True)"
+      ]
+     },
+     "execution_count": 184,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "a"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 185,
    "id": "ce2ddac6-6f8c-4737-8995-e954ee78e57f",
    "metadata": {},
    "outputs": [
@@ -525,32 +571,29 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "tensor([3, 1, 3])\n",
-      "tensor([[ 0.3347,  0.6775, -1.7282],\n",
-      "        [ 2.3341, -1.9627,  0.5752],\n",
-      "        [-0.8408,  0.4555,  1.3133]])\n"
+      "tensor([[0.4981, 0.3462, 0.0865],\n",
+      "        [0.9151, 0.9980, 0.9033],\n",
+      "        [0.3711, 0.4656, 0.9315]], grad_fn=<IndexSelectBackward0>)\n"
      ]
     }
    ],
    "source": [
-    "print(model.raw_to_sorted_data(\n",
-    "    a\n",
-    "))"
+    "print(model(a))"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 144,
+   "execution_count": 186,
    "id": "fdd8a120-797d-463e-8a0c-8a8e2a2270fd",
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "tensor([3, 1, 3])"
+       "tensor([2, 3, 3])"
       ]
      },
-     "execution_count": 144,
+     "execution_count": 186,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -561,8 +604,29 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 188,
    "id": "78806920-c70a-42a8-a3d0-9f25a3aec0a1",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "True"
+      ]
+     },
+     "execution_count": 188,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "model(a).requires_grad"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f91c1127-f05a-4ce8-8788-fcee628d11ea",
    "metadata": {},
    "outputs": [],
    "source": []


### PR DESCRIPTION
## LSHアルゴリズムとハッシュ値からソートするクラスの実装
---
<img width="744" alt="スクリーンショット 2024-02-07 23 40 29" src="https://github.com/odango314159/ReformerImp/assets/145087663/a1a812d1-b0d1-4b2e-9f46-dc8249564a48">. 
ここの部分

### 使い方
<img width="194" alt="スクリーンショット 2024-02-07 23 42 43" src="https://github.com/odango314159/ReformerImp/assets/145087663/8ed1531d-f03c-4041-95e2-596e901e9acc">. 
<img width="300" alt="スクリーンショット 2024-02-07 23 43 36" src="https://github.com/odango314159/ReformerImp/assets/145087663/b42ebb77-ada3-46c6-be83-ace02af8d8f7">. 
aはtorch.tensorの行列。num_length×d_modelの行列を想定している。  
バケットの数をコンストラクタで指定する. 
raw_to_sorted_data()関数に行列を入力するとソートされた関数が出てくる. 
<img width="149" alt="スクリーンショット 2024-02-07 23 45 34" src="https://github.com/odango314159/ReformerImp/assets/145087663/5a735632-c8cc-4b9f-954c-c859ee260914">  
インスタンス変数としてlabelsにアクセスすることで計算されたハッシュの値を確認することができる. 